### PR TITLE
2 patches for inferno transition group

### DIFF
--- a/src/TransitionGroup.js
+++ b/src/TransitionGroup.js
@@ -173,7 +173,7 @@ export class TransitionGroup extends Component {
 				childrenToRender.push(el);
 			}
 		}
-
-		return createVNode(typeof component === 'string' ? 2 : 16, component, props, childrenToRender);
+		
+		return createVNode(typeof component === 'string' ? 2 : 16, component, props && props.className, childrenToRender, props);
 	}
 }

--- a/src/util.js
+++ b/src/util.js
@@ -4,6 +4,6 @@ export function assign(obj, props) {
 }
 
 export function getKey(vnode, fallback) {
-	var key = vnode.key || (vnode.attributes && vnode.attributes.key);
+	let key = vnode.key;
 	return key===null || key===undefined ? fallback : key;
 }

--- a/src/util.js
+++ b/src/util.js
@@ -4,6 +4,6 @@ export function assign(obj, props) {
 }
 
 export function getKey(vnode, fallback) {
-	let key = vnode.attributes && vnode.attributes.key;
+	var key = vnode.key || (vnode.attributes && vnode.attributes.key);
 	return key===null || key===undefined ? fallback : key;
 }


### PR DESCRIPTION
I working on react's fork https://github.com/kurdin/velocity-inferno and found 2 problems with inferno-transition-group that it was based of. Those problems might appeared after inferno upgrade to 3.x.x version. 